### PR TITLE
Relax dependency requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed CI workflows to run pre-commit with poetry. ([#131](https://github.com/Rose-STL-Lab/torchTS/pull/131))
 - Moved common workflow steps to a composite action. ([#132](https://github.com/Rose-STL-Lab/torchTS/pull/132))
 - Updated pre-commit hooks. ([#133](https://github.com/Rose-STL-Lab/torchTS/pull/133), [#135](https://github.com/Rose-STL-Lab/torchTS/pull/135))
+- Relaxed dependency requirements. ([#139](https://github.com/Rose-STL-Lab/torchTS/pull/139))
 
 ### Fixed
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -919,7 +919,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.10"
-content-hash = "7a6bbb389a49069d7ccb1c0b46b9ea8bc6fe49088332c1c194ce7bc86fd7cb28"
+content-hash = "1d9bb2dc95a37304998915ea4fd49669ca60ba38366b0db21b8f9420d8da5c5a"
 
 [metadata.files]
 absl-py = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7,<3.10"
-torch = "^1.9.0"
-pytorch-lightning = "^1.4.1"
+torch = "^1.4"
+pytorch-lightning = "^1.2"
 scipy = "^1.7.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
The dependency requirements in `pyproject.toml` are too strict for the conda-forge recipe proposed in https://github.com/conda-forge/staged-recipes/pull/16014. Relaxing the requirements should resolve this issue.